### PR TITLE
Enable the automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
+    <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 
   <dependencyManagement>

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,2 @@
-Automatic-Module-Name: io.vertx.bridge.common
+Automatic-Module-Name: io.vertx.eventbusbridge.common
 

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Automatic-Module-Name: io.vertx.bridge.common
+


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Adds a automatic module to bridge common.

Fixes https://github.com/vert-x3/vertx-web/issues/1616