### PR TITLE
Add a new event SOCKET_EXCEPTION to signal general socket failures

### DIFF
--- a/src/main/java/io/vertx/ext/bridge/BridgeEventType.java
+++ b/src/main/java/io/vertx/ext/bridge/BridgeEventType.java
@@ -31,6 +31,11 @@ public enum BridgeEventType {
   SOCKET_PING,
 
   /**
+   * This event will occur when SockJS socket exception handler is triggered.
+   */
+  SOCKET_EXCEPTION,
+
+  /**
    * This event will occur when a message is attempted to be sent from the client to the server.
    */
   SEND,


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Address socket failures like in: https://github.com/vert-x3/vertx-web/issues/1986